### PR TITLE
Include DSA keys in the patterns...

### DIFF
--- a/patterns.json
+++ b/patterns.json
@@ -9,6 +9,13 @@
     {
         "part": "filename",
         "type": "match",
+        "pattern": "id_dsa",
+        "caption": "Private SSH key",
+        "description": null
+    },
+    {
+        "part": "filename",
+        "type": "match",
         "pattern": "id_ed25519",
         "caption": "Private SSH key",
         "description": null


### PR DESCRIPTION
It's 2015, and yes, sadly, people are **still** using DSA keys for SSH.