### PR TITLE
find private SSH key with any base name

### DIFF
--- a/patterns.json
+++ b/patterns.json
@@ -9,6 +9,13 @@
     {
         "part": "filename",
         "type": "regex",
+        "pattern": "\\A.*_dsa\\z",
+        "caption": "Private SSH key",
+        "description": null
+    },
+    {
+        "part": "filename",
+        "type": "regex",
         "pattern": "\\A.*_ed25519\\z",
         "caption": "Private SSH key",
         "description": null

--- a/patterns.json
+++ b/patterns.json
@@ -1,22 +1,22 @@
 [
     {
         "part": "filename",
-        "type": "match",
-        "pattern": "id_rsa",
+        "type": "regex",
+        "pattern": "\\A.*_rsa\\z",
         "caption": "Private SSH key",
         "description": null
     },
     {
         "part": "filename",
-        "type": "match",
-        "pattern": "id_ed25519",
+        "type": "regex",
+        "pattern": "\\A.*_ed25519\\z",
         "caption": "Private SSH key",
         "description": null
     },
     {
         "part": "filename",
-        "type": "match",
-        "pattern": "id_ecdsa",
+        "type": "regex",
+        "pattern": "\\A.*_ecdsa\\z",
         "caption": "Private SSH key",
         "description": null
     },


### PR DESCRIPTION
First thank you for that great tool!

Scanning some of our repos I have adjusted the patterns.json to find SSH key files with any base name, eg. `jenkins_rsa`.
