### PR TITLE
Add matching pattern for msbuild publish profile.

### DIFF
--- a/patterns.json
+++ b/patterns.json
@@ -345,7 +345,7 @@
     {
         "part": "filename",
         "type": "regex",
-        "pattern": "*\\.pubxml(\\.user)?",
+        "pattern": "\\A*\\.pubxml(\\.user)?\\z",
         "caption": "Potential MSBuild publish profile",
         "description": null
     }

--- a/patterns.json
+++ b/patterns.json
@@ -341,5 +341,12 @@
         "pattern": "credentials.xml",
         "caption": "Potential Jenkins credentials file",
         "description": null
+    },
+    {
+        "part": "filename",
+        "type": "regex",
+        "pattern": "*\\.pubxml(\\.user)?",
+        "caption": "Potential MSBuild publish profile",
+        "description": null
     }
 ]


### PR DESCRIPTION
Matching files ending in ".pubxml" or ".pubxml.user".

These files often contain connection strings with passwords in plaintext, among other sensitive infos.