### PR TITLE
Add Ruby dependency to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All of the members, repositories and files will be saved to a PostgreSQL databas
 
 ## Installation
 
-Gitrob is written in Ruby and requires at least version 1.9.3 or above, except for version 2.2.0 which is currently not compatible. If you are on an older version, it is very easy to install newer versions with [RVM](http://rvm.io/). If you are installing Gitrob on [Kali](http://www.kali.org/), you are almost good to go, you just need to update Bundler with `gem install bundler`. It might also be necessary to install a PostgreSQL dependency with `apt-get install postgresql-server-dev-9.1` in a terminal.
+Gitrob is written in Ruby and requires at least version 1.9.3 or above, except for version 2.2.0 which is currently not compatible. If you are on an older version, it is very easy to install newer versions with [RVM](http://rvm.io/). If you are installing Gitrob on [Kali](http://www.kali.org/), you are almost good to go, you just need to update Bundler with `gem install bundler`. It might also be necessary to install a PostgreSQL dependency with `apt-get install postgresql-server-dev-9.1` and a Ruby dependency with `apt-get install ruby1.9.1-dev` in a terminal.
 
 Gitrob is a Ruby gem, so installation is a simple `gem install gitrob` in a terminal. This will automatically install all the code dependencies as well.
 


### PR DESCRIPTION
While executing `gem install gitrob` on Kali Linux, I ran into the following error:

> user@kali:~/src/gitrob$ gem install gitrob
Fetching: multi_xml-0.5.5.gem (100%)
Fetching: httparty-0.13.3.gem (100%)
When you HTTParty, you must party hard!
Fetching: methadone-1.8.0.gem (100%)
Fetching: highline-1.6.21.gem (100%)
Fetching: paint-0.9.0.gem (100%)
Fetching: thread-0.1.4.gem (100%)
Fetching: thin-1.6.3.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing gitrob:
	ERROR: Failed to build gem native extension.

> /usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)

> from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'

> from extconf.rb:1:in `\<main\>'

Installing `ruby1.9.1-dev` fixed the problem.