### PR TITLE
Added terraform.tfvars to signatures.json

### DIFF
--- a/signatures.json
+++ b/signatures.json
@@ -537,5 +537,12 @@
     "pattern": "\\A\\.?npmrc\\z",
     "caption": "NPM configuration file",
     "description": "Might contain credentials for NPM registries"
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "terraform.tfvars",
+    "caption": "Terraform variable config file",
+    "description": "Might contain credentials for terraform providers"
   }
 ]


### PR DESCRIPTION
terraform.tfvars can contain AWS admin keys or credentials for any of the providers at https://www.terraform.io/docs/providers/index.html