### PR TITLE
Add support for disabling signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,17 @@ Have a look at the main [signatures.json](signatures.json) file for more example
 
 **If you think other people can benefit from your custom signatures, please consider contributing them back to the Gitrob project by opening a Pull Request or an Issue. Thanks!**
 
-### Disbling signatures
-If you would like to disable signatures so that you don't see them in any report you can do so by disabling their pattern.
+### Ignoring signatures
+If you would like to ignore signatures so that you don't see them in any report you can do so by disabling their pattern.
 
-When Gitrob starts it looks for a file at `~/.gitrob_disabled_signatures` which it expects to be a JSON document containing an array of patterns that you want to disable. Here is an example:
+When Gitrob starts it looks for a file at `~/.gitrobignore` which it expects to be a JSON document containing an array of patterns that you want to ignore. Here is an example:
 
     [
-      "database.yml",
-      "dump"
+      {
+        "part": "filename",
+        "type": "match",
+        "pattern": "database.yml"
+      }
     ]
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ Have a look at the main [signatures.json](signatures.json) file for more example
 
 **If you think other people can benefit from your custom signatures, please consider contributing them back to the Gitrob project by opening a Pull Request or an Issue. Thanks!**
 
+### Disbling signatures
+If you would like to disable signatures so that you don't see them in any report you can do so by disabling their pattern.
+
+When Gitrob starts it looks for a file at `~/.gitrob_disabled_signatures` which it expects to be a JSON document containing an array of patterns that you want to disable. Here is an example:
+
+    [
+      "database.yml",
+      "dump"
+    ]
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. Run `bundle exec gitrob` to use the gem in this directory, ignoring other installed copies of this gem.

--- a/lib/gitrob/blob_observer.rb
+++ b/lib/gitrob/blob_observer.rb
@@ -4,6 +4,8 @@ module Gitrob
       "../../../signatures.json", __FILE__)
     CUSTOM_SIGNATURES_FILE_PATH = File.join(
       Dir.home, ".gitrobsignatures")
+    DISABLED_SIGNATURES_FILE_PATH = File.join(
+      Dir.home, ".gitrob_disabled_signatures")
 
     REQUIRED_SIGNATURE_KEYS = %w(part type pattern caption description)
     ALLOWED_TYPES           = %w(regex match)
@@ -28,6 +30,22 @@ module Gitrob
     def self.signatures
       load_signatures! unless @signatures
       @signatures
+    end
+
+    def self.disabled_signatures
+      @disabled_signatures
+    end
+
+    def self.disabled_signatures?
+      File.exist?(DISABLED_SIGNATURES_FILE_PATH)
+    end
+
+    def self.disable_signatures!
+      disabled_signatures = JSON.load(File.read(DISABLED_SIGNATURES_FILE_PATH))
+      @disabled_signatures = []
+      disabled_signatures.each do |pattern|
+        @disabled_signatures << @signatures.delete_if { |sig| sig['pattern'] == pattern }
+      end
     end
 
     def self.load_signatures!

--- a/lib/gitrob/cli/commands/analyze.rb
+++ b/lib/gitrob/cli/commands/analyze.rb
@@ -13,7 +13,7 @@ module Gitrob
           @options = options
           @targets = targets.split(",").map(&:strip).uniq
           load_signatures!
-          disable_signatures!
+          load_ignored_signatures!
           create_database_assessment
           gather_owners
           gather_repositories
@@ -37,12 +37,12 @@ module Gitrob
           end
         end
 
-        def disable_signatures!
-          return unless Gitrob::BlobObserver.disabled_signatures?
-          task("Disabling signatures...", true) do
-            Gitrob::BlobObserver.disable_signatures!
+        def load_ignored_signatures!
+          return unless Gitrob::BlobObserver.ignored_signatures?
+          task("Ignoring signatures...", true) do
+            Gitrob::BlobObserver.load_ignored_signatures!
           end
-          info("Disabled #{Gitrob::BlobObserver.disabled_signatures.count} signatures")
+          info("Ignored #{Gitrob::BlobObserver.ignored_signatures.count} signatures")
           info("There are #{Gitrob::BlobObserver.signatures.count} enabled signatures")
         end
 

--- a/lib/gitrob/cli/commands/analyze.rb
+++ b/lib/gitrob/cli/commands/analyze.rb
@@ -13,6 +13,7 @@ module Gitrob
           @options = options
           @targets = targets.split(",").map(&:strip).uniq
           load_signatures!
+          disable_signatures!
           create_database_assessment
           gather_owners
           gather_repositories
@@ -34,6 +35,15 @@ module Gitrob
           github_access_tokens.each do |access_token|
             @db_assessment.save_github_access_token(access_token)
           end
+        end
+
+        def disable_signatures!
+          return unless Gitrob::BlobObserver.disabled_signatures?
+          task("Disabling signatures...", true) do
+            Gitrob::BlobObserver.disable_signatures!
+          end
+          info("Disabled #{Gitrob::BlobObserver.disabled_signatures.count} signatures")
+          info("There are #{Gitrob::BlobObserver.signatures.count} enabled signatures")
         end
 
         def load_signatures!


### PR DESCRIPTION
I'd like to be able to disable signatures so that I can filter down signatures that I either want to deal with later or don't find useful. This is especially when trying to roll out gitrob across a large organization. 

This PR isn't final, I wanted to hammer out a basic outline and then poll for thoughts. (It does work though)
- I'm not sure if I like having just an array of patterns.
  - I didn't notice any duplicate patterns that were match vs regex, but it could happen I believe
  - However, it seemed cumbersome to basically duplicate the signature just to disable it
  - Ideally, it would be an array of names/ids for the signature, but there isn't such a field currently.
- Gotta write tests, but the tests don't pass for me on master. I suspect I'm just missing some config, but there wasn't much documentation in the readme
