### PR TITLE
FIX InvalidURIError during config by encoding URI #94

### DIFF
--- a/lib/gitrob/cli/commands/configure.rb
+++ b/lib/gitrob/cli/commands/configure.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 module Gitrob
   class CLI
     module Commands
@@ -102,7 +104,8 @@ module Gitrob
         end
 
         def make_connection_uri(username, password, hostname, port, database)
-          "postgres://#{username}:#{password}@#{hostname}:#{port}/#{database}"
+          str = "postgres://#{username}:#{password}@#{hostname}:#{port}/#{database}"
+          URI::encode(str)
         end
 
         def build_yaml(config)


### PR DESCRIPTION
This PR encodes the postgres URI generated during configuration so to support spaces and other characters in passwords and usernames.

Closes #94 
