### PR TITLE
Remove inaccurate statement on scanning of an organization's users

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Analyzing organizations and users is the main feature of Gitrob. The `analyze` c
 
     gitrob analyze acme,johndoe,janedoe
 
-Mixing organizations and users is convenient if you know that a certain user is part of an organization but they do not have their membership public.
-
 When the assessment is finished, the `analyze` command will automatically start up the web server to present the results. This can be avoided by adding the `--no-server` option to the command.
 
 See `gitrob help analyze` for more options.


### PR DESCRIPTION
> Mixing organizations and users is convenient if you know that a certain user is part of an organization but they do not have their membership public.

I tried to verify this statement as it is not what I am seeing when I run a scan on an organization i.e even users who are concealed are also scanned. 

From the [documentation](https://developer.github.com/v3/orgs/members/#members-list) of github api, the [call to github_api's client.orgs.members.list](https://developer.github.com/v3/orgs/members/#members-list) should return both concealed and public members of an organization:

> List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.

Perhaps the statement can be modified to consider: 
- the user credential given to gitrob is not part of an organization and 
- the scanner knows that another github user is part of the organization but that user's membershipt to the organization is concealed. 

I have not tested the above though. 