### PR TITLE
Gitrob Enhancement (False Positives handling, User Auth)

### DIFF
--- a/db/migrations/005_create_blobs.rb
+++ b/db/migrations/005_create_blobs.rb
@@ -8,6 +8,7 @@ Sequel.migration do
       String :path
       Integer :size, :index => true
       String :sha, :size => 40, :fixed => true, :index => true
+      String :sha256, :size => 64, :fixed => true, :index => true
       Integer :flags_count, :index => true, :default => 0
       DateTime :updated_at
       DateTime :created_at

--- a/db/migrations/011_create_falsepositives.rb
+++ b/db/migrations/011_create_falsepositives.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  change do
+    create_table(:false_positives) do
+      primary_key :id
+      String :repository, :size => 100
+      String :path, :size => 100 
+      String :fingerprint, :size => 65, :fixed => true, :index => true
+    end
+  end
+end

--- a/db/migrations/012_create_user.rb
+++ b/db/migrations/012_create_user.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    create_table(:gitrob_users) do
+      primary_key :id
+      String :username, :size => 100
+      String :password_digest, :size => 100
+    end
+  end
+end

--- a/gitrob.gemspec
+++ b/gitrob.gemspec
@@ -30,6 +30,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "github_api", "0.13"
   spec.add_dependency "hashie", "~> 3.5", ">= 3.5.5"
   spec.add_dependency "sucker_punch", "~> 2.0", ">= 2.0.1"
+  spec.add_dependency "warden", "~> 1.2.6"
+  spec.add_dependency "bcrypt-ruby", "~> 3.1.5"
+  spec.add_dependency "sequel_secure_password", "~> 0.2.14"
+  spec.add_dependency "sinatra-flash", "~> 0.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/gitrob.rb
+++ b/lib/gitrob.rb
@@ -11,6 +11,7 @@ require "thread/pool"
 require "sequel"
 require "ruby-progressbar"
 require "sucker_punch"
+require "securerandom"
 
 require "gitrob/version"
 require "gitrob/utils"

--- a/lib/gitrob/cli.rb
+++ b/lib/gitrob/cli.rb
@@ -81,7 +81,7 @@ module Gitrob
            :type    => :boolean,
            :default => true,
            :desc    => "Verify or don't verify SSL connection (careful here)"
-    # Zendesk - Option to disable / enable org member scan
+    #Option to disable / enable org member scan
     option :scan_org_members,
            :type    => :boolean,
            :default => false,
@@ -142,7 +142,7 @@ module Gitrob
         end
       end
 
-      #Zendesk - Create new Gitrob User
+      #Create new Gitrob User during first run
       def prepare_user
         @gitrobUser = Gitrob::Models::GitrobUser.all
         if @gitrobUser.count == 0

--- a/lib/gitrob/cli.rb
+++ b/lib/gitrob/cli.rb
@@ -52,6 +52,7 @@ module Gitrob
       configure unless configured?
       load_configuration
       prepare_database
+      prepare_user
     end
 
     desc "analyze TARGETS", "Analyze one or more organizations or users"
@@ -141,6 +142,27 @@ module Gitrob
         end
       end
 
+      #Zendesk - Create new Gitrob User
+      def prepare_user
+        @gitrobUser = Gitrob::Models::GitrobUser.all
+        if @gitrobUser.count == 0
+          username = "gitrob"
+          random_string = SecureRandom.base64(75)
+          puts "\033[0;31m"
+          puts "============================================================"
+          puts "Password only generated once. Please save it somewhere safe!"
+          puts "Creating new User for Gitrob"
+          puts "Username: " + username
+          puts "Password: " + random_string
+          puts "============================================================"
+          puts "\e[0"
+          @user = Gitrob::Models::GitrobUser.new
+          @user.username = username
+          @user.password = random_string
+          @user.save       
+        end
+      end
+
       def load_models
         require "gitrob/models/assessment"
         require "gitrob/models/github_access_token"
@@ -150,6 +172,7 @@ module Gitrob
         require "gitrob/models/flag"
         require "gitrob/models/comparison"
         require "gitrob/models/fingerprint"
+        require "gitrob/models/gitrob_user"
       end
     end
 

--- a/lib/gitrob/cli.rb
+++ b/lib/gitrob/cli.rb
@@ -80,6 +80,11 @@ module Gitrob
            :type    => :boolean,
            :default => true,
            :desc    => "Verify or don't verify SSL connection (careful here)"
+    # Zendesk - Option to disable / enable org member scan
+    option :scan_org_members,
+           :type    => :boolean,
+           :default => false,
+           :desc    => "Options to enable/disable organiztion members scan"
     def analyze(targets)
       accept_tos
       Gitrob::CLI::Commands::Analyze.start(targets, options)
@@ -144,6 +149,7 @@ module Gitrob
         require "gitrob/models/blob"
         require "gitrob/models/flag"
         require "gitrob/models/comparison"
+        require "gitrob/models/fingerprint"
       end
     end
 

--- a/lib/gitrob/cli/commands/analyze.rb
+++ b/lib/gitrob/cli/commands/analyze.rb
@@ -11,6 +11,7 @@ module Gitrob
         def initialize(targets, options)
           Thread.abort_on_exception = true
           @options = options
+          @scan_member = @options[:scan_org_members]
           @targets = targets.split(",").map(&:strip).uniq
           load_signatures!
           create_database_assessment

--- a/lib/gitrob/cli/commands/analyze/analysis.rb
+++ b/lib/gitrob/cli/commands/analyze/analysis.rb
@@ -4,7 +4,7 @@ module Gitrob
       class Analyze < Gitrob::CLI::Command
         module Analysis
           def analyze_repositories
-            #Zendesk - load false positive fingerprints
+            #Load false positive fingerprints
             loadFalsePositive
             repo_progress_bar do |progress|
               github_data_manager.owners.each do |owner|
@@ -27,7 +27,7 @@ module Gitrob
             blobs.each do |blob|
               db_blob = @db_assessment.save_blob(blob, db_repo, db_owner)
 
-              #Zendesk - Do a fingerprint comparison before observing blob
+              #Do a fingerprint comparison before observing blob
               if !@falsePositiveFingerprints.to_s.include? db_blob.sha256
                 Gitrob::BlobObserver.observe(db_blob)
               end

--- a/lib/gitrob/cli/commands/analyze/analysis.rb
+++ b/lib/gitrob/cli/commands/analyze/analysis.rb
@@ -28,7 +28,7 @@ module Gitrob
               db_blob = @db_assessment.save_blob(blob, db_repo, db_owner)
 
               #Zendesk - Do a fingerprint comparison before observing blob
-              if !@falsePositiveFingerprints.include? db_blob.sha256
+              if !@falsePositiveFingerprints.to_s.include? db_blob.sha256
                 Gitrob::BlobObserver.observe(db_blob)
               end
               

--- a/lib/gitrob/cli/commands/analyze/analysis.rb
+++ b/lib/gitrob/cli/commands/analyze/analysis.rb
@@ -4,6 +4,8 @@ module Gitrob
       class Analyze < Gitrob::CLI::Command
         module Analysis
           def analyze_repositories
+            #Zendesk - load false positive fingerprints
+            loadFalsePositive
             repo_progress_bar do |progress|
               github_data_manager.owners.each do |owner|
                 @db_owner = @db_assessment.save_owner(owner)
@@ -24,7 +26,12 @@ module Gitrob
             findings = 0
             blobs.each do |blob|
               db_blob = @db_assessment.save_blob(blob, db_repo, db_owner)
-              Gitrob::BlobObserver.observe(db_blob)
+
+              #Zendesk - Do a fingerprint comparison before observing blob
+              if !@falsePositiveFingerprints.include? db_blob.sha256
+                Gitrob::BlobObserver.observe(db_blob)
+              end
+              
               if db_blob.flags.count > 0
                 findings += 1
                 @db_assessment.findings_count += 1
@@ -38,6 +45,15 @@ module Gitrob
             report_findings(findings, db_repo, progress)
           rescue => e
             progress.error("#{e.class}: #{e.message}")
+          end
+
+          #Loading false positives from database
+          def loadFalsePositive
+            @falsePositiveFingerprints =[]
+            @loadDatabase = Gitrob::Models::FalsePositive.dataset.all
+            @loadDatabase.each do |e|
+              @falsePositiveFingerprints << e.fingerprint
+            end
           end
 
           def report_findings(finding_count, repo, progress)

--- a/lib/gitrob/cli/commands/analyze/gathering.rb
+++ b/lib/gitrob/cli/commands/analyze/gathering.rb
@@ -6,7 +6,7 @@ module Gitrob
           def gather_owners
             task("Gathering targets...") do
               thread_pool do |pool|
-                #Zendesk - Transfer @scan_member variable
+                #Transfer @scan_member variable
                 github_data_manager.gather_owners(pool, @scan_member)
               end
             end

--- a/lib/gitrob/cli/commands/analyze/gathering.rb
+++ b/lib/gitrob/cli/commands/analyze/gathering.rb
@@ -6,7 +6,8 @@ module Gitrob
           def gather_owners
             task("Gathering targets...") do
               thread_pool do |pool|
-                github_data_manager.gather_owners(pool)
+                #Zendesk - Transfer @scan_member variable
+                github_data_manager.gather_owners(pool, @scan_member)
               end
             end
             fatal("No users or organizations " \

--- a/lib/gitrob/github/data_manager.rb
+++ b/lib/gitrob/github/data_manager.rb
@@ -23,7 +23,7 @@ module Gitrob
           @owners << owner
           @repositories_for_owners[owner["login"]] = []
           next unless owner["type"] == "Organization"
-          #Zendesk - disable scanning of members in Organization
+          #Option to disable scanning of members in Organization
           if scan_member
             get_members(owner, thread_pool) if owner["type"] == "Organization"
           end
@@ -108,7 +108,7 @@ module Gitrob
         end
       end
 
-      #Zendesk - Counter so as we won't hit Github Rate Limit
+      #Method Counter so as we won't hit Github Rate Limit
       def incrementCounter
         if @method_counter == 1000
           puts "Job paused for 1 Hour. Max Github request reached."

--- a/lib/gitrob/models/assessment.rb
+++ b/lib/gitrob/models/assessment.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 module Gitrob
   module Models
     class Assessment < Sequel::Model
@@ -58,7 +60,19 @@ module Gitrob
         blob.owner.save
         blob.repository.blobs_count += 1
         blob.repository.save
+        blob.sha256 = blob_fingerprint(blob)
         add_blob(blob)
+      end
+
+      #Zendesk - create blob fingerprint
+      def blob_fingerprint(blob)
+        sha = blob.sha
+        path = blob.path
+        repository_name = blob.repository.full_name
+        owner_name = blob.owner.name
+        attributes = sha + path + repository_name + owner_name
+        digest = Digest::SHA256.hexdigest attributes
+        return digest
       end
 
       def save_github_access_token(token)

--- a/lib/gitrob/models/assessment.rb
+++ b/lib/gitrob/models/assessment.rb
@@ -64,7 +64,7 @@ module Gitrob
         add_blob(blob)
       end
 
-      #Zendesk - create blob fingerprint
+      #create blob fingerprint
       def blob_fingerprint(blob)
         sha = blob.sha
         path = blob.path

--- a/lib/gitrob/models/blob.rb
+++ b/lib/gitrob/models/blob.rb
@@ -1,7 +1,7 @@
 module Gitrob
   module Models
     class Blob < Sequel::Model
-      set_allowed_columns :path, :size, :sha
+      set_allowed_columns :path, :size, :sha, :sha256
 
       SHA_REGEX = /[a-f0-9]{40}/
       TEST_BLOB_INDICATORS = %w(test spec fixture mock stub fake demo sample)

--- a/lib/gitrob/models/fingerprint.rb
+++ b/lib/gitrob/models/fingerprint.rb
@@ -1,4 +1,4 @@
-#Zendesk - FalsePositive Model
+#FalsePositive Model
 module Gitrob
   module Models
     class FalsePositive < Sequel::Model

--- a/lib/gitrob/models/fingerprint.rb
+++ b/lib/gitrob/models/fingerprint.rb
@@ -1,0 +1,8 @@
+#Zendesk - FalsePositive Model
+module Gitrob
+  module Models
+    class FalsePositive < Sequel::Model
+      set_allowed_columns :fingerprint, :path, :repository
+    end
+  end
+end

--- a/lib/gitrob/models/fingerprint.rb
+++ b/lib/gitrob/models/fingerprint.rb
@@ -11,6 +11,7 @@ module Gitrob
         validates_unique(:fingerprint, :path, :repository)
         validates_presence [:fingerprint, :path, :repository]
         validates_format SHA_REGEX, :fingerprint
+      end
     end
   end
 end

--- a/lib/gitrob/models/fingerprint.rb
+++ b/lib/gitrob/models/fingerprint.rb
@@ -3,6 +3,14 @@ module Gitrob
   module Models
     class FalsePositive < Sequel::Model
       set_allowed_columns :fingerprint, :path, :repository
+
+      SHA_REGEX = /[a-f0-9]{64}/
+ 
+      def validate
+        super
+        validates_unique(:fingerprint, :path, :repository)
+        validates_presence [:fingerprint, :path, :repository]
+        validates_format SHA_REGEX, :fingerprint
     end
   end
 end

--- a/lib/gitrob/models/fingerprint.rb
+++ b/lib/gitrob/models/fingerprint.rb
@@ -5,7 +5,7 @@ module Gitrob
       set_allowed_columns :fingerprint, :path, :repository
       
       SHA_REGEX = /[a-f0-9]{64}/
- 
+      
       def validate
         super
         validates_unique(:fingerprint, :path, :repository)

--- a/lib/gitrob/models/gitrob_user.rb
+++ b/lib/gitrob/models/gitrob_user.rb
@@ -1,4 +1,4 @@
-#Zendesk - Gitrob User Model
+#Gitrob User Model
 module Gitrob
   module Models
     class GitrobUser < Sequel::Model

--- a/lib/gitrob/models/gitrob_user.rb
+++ b/lib/gitrob/models/gitrob_user.rb
@@ -1,0 +1,14 @@
+#Zendesk - Gitrob User Model
+module Gitrob
+  module Models
+    class GitrobUser < Sequel::Model
+      plugin :secure_password, include_validations: false
+      set_allowed_columns :username, :password_digest
+
+      def validate
+        super
+        validates_presence [:username, :password_digest]
+      end
+    end
+  end
+end

--- a/lib/gitrob/web_app.rb
+++ b/lib/gitrob/web_app.rb
@@ -177,6 +177,54 @@ module Gitrob
       erb :"assessments/compare"
     end
 
+    #Zendesk - Get request for false_positive table
+    get "/assessments/:id/false_positives" do
+      @assessment = find_assessment(params[:id])
+      @falsePositive = Gitrob::Models::FalsePositive.order(:repository)
+      erb :"assessments/false_positive"
+    end
+
+    #Zendesk - Get request for false_positive table
+    get "/assessments/:id/:findingID/false_positives" do
+      @assessment = find_assessment(params[:id])
+
+      @path = Gitrob::Models::Blob.where(:id => params[:findingID]).all
+      @path.each do |p|
+        @fullpath = p.path
+        @sha256 = p.sha256
+        @repo_id = p.repository_id
+      end
+      @repository = Gitrob::Models::Repository.where(:id => @repo_id).all
+      @repository.each do |r|
+        @repo_name = r.full_name  
+      end
+      @falsePositive = Gitrob::Models::FalsePositive.order(:repository)
+      erb :"assessments/false_positive"
+    end
+
+    #Zendesk - Get request for false_positive table
+    get "/falsePositive/_table" do
+      @falsePositive = Gitrob::Models::FalsePositive.order(:repository)
+      erb :"assessments/_falsePositiveTable", :layout => false
+    end
+
+    #Zendesk - Delete false positive fingerprints
+    delete "/false_positive/:id" do
+      @falsePositive = Gitrob::Models::FalsePositive.first(
+        :id       => params[:id].to_i,
+      ) || halt(404)
+      @falsePositive.destroy
+    end
+
+    #Zendesk - Add new false positive fingerprints
+    post "/falsePositive" do
+      @fingerprint = Gitrob::Models::FalsePositive.new
+      @fingerprint.fingerprint = params[:falsePositive][:fingerprint]
+      @fingerprint.path = params[:falsePositive][:path]
+      @fingerprint.repository = params[:falsePositive][:repository]
+      @fingerprint.save
+    end
+
     get "/assessments/:id/compare/_comparables" do
       @assessment = find_assessment(params[:id])
       @assessments = @assessment.comparable_assessments

--- a/lib/gitrob/web_app.rb
+++ b/lib/gitrob/web_app.rb
@@ -256,7 +256,7 @@ module Gitrob
       erb :"assessments/compare"
     end
 
-    #Zendesk - Get request for false_positive table
+    #Get request for false_positive table
     get "/assessments/:id/false_positives" do
       env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
@@ -264,7 +264,7 @@ module Gitrob
       erb :"assessments/false_positive"
     end
 
-    #Zendesk - Get request for false_positive table
+    #Get request for false_positive table
     get "/assessments/:id/:findingID/false_positives" do
       env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
@@ -283,14 +283,14 @@ module Gitrob
       erb :"assessments/false_positive"
     end
 
-    #Zendesk - Get request for false_positive table
+    #Get request for false_positive table
     get "/falsePositive/_table" do
       env['warden'].authenticate!
       @falsePositive = Gitrob::Models::FalsePositive.order(:repository)
       erb :"assessments/_falsePositiveTable", :layout => false
     end
 
-    #Zendesk - Delete false positive fingerprints
+    #Delete false positive fingerprints
     delete "/false_positive/:id" do
       env['warden'].authenticate!
       @falsePositive = Gitrob::Models::FalsePositive.first(
@@ -299,7 +299,7 @@ module Gitrob
       @falsePositive.destroy
     end
 
-    #Zendesk - Add new false positive fingerprints
+    #Add new false positive fingerprints
     post "/falsePositive" do
       env['warden'].authenticate!
       @fingerprint = Gitrob::Models::FalsePositive.new

--- a/lib/gitrob/web_app.rb
+++ b/lib/gitrob/web_app.rb
@@ -1,5 +1,6 @@
 require "sinatra/base"
-require "thin"
+require "warden"
+require 'sinatra/flash'
 
 module Gitrob
   class WebApp < Sinatra::Base
@@ -16,6 +17,10 @@ module Gitrob
     set :public_folder, proc { File.join(root, "public") }
     set :views, proc { File.join(root, "views") }
     set :run, proc { false }
+
+    # Warden configuration code
+    enable :sessions
+    register Sinatra::Flash
 
     helpers do
       HUMAN_PREFIXES = %w(TB GB MB KB B).freeze
@@ -94,7 +99,74 @@ module Gitrob
       protect_from_request_forgery!
     end
 
+    use Warden::Manager do |config|
+      config.serialize_into_session{|user| user.id}
+      config.serialize_from_session{|id| Gitrob::Models::GitrobUser.get(id)}
+
+      config.scope_defaults :default,
+        strategies: [:password],
+        action: '/auth/unathenticated'
+      config.failure_app = self
+    end
+
+    Warden::Manager.before_failure do |env,opts|
+      env['REQUEST_METHOD'] = 'GET'
+      env.each do |key, value|
+        env[key]['_method'] = 'get' if key == 'rack.request.form_hash'
+      end
+    end
+
+    Warden::Strategies.add(:password) do
+      def valid?
+        params['user'] && params['user']['username'] && params['user']['password']
+      end
+
+      def authenticate!
+        user = Gitrob::Models::GitrobUser.first(username: params['user']['username'])
+        if user.nil?
+          throw(:warden, message: "The username and passowrd combination is incorrect.")
+        elsif user.authenticate(params['user']['password'])
+          success!(user)
+        else
+          throw(:warden, message: "The username and password combination is incorrect.")
+        end
+      end
+    end  
+
+    get '/auth/login' do
+      erb :"auth/login"
+    end
+
+    get '/auth/logout' do
+      env['warden'].raw_session.inspect
+      env['warden'].logout
+      session[:login] = false
+      flash[:success] = 'Successfully logged out'
+      redirect '/auth/login'
+    end
+
+    post '/auth/login' do
+      env['warden'].authenticate!
+      flash[:success] = "Successfully logged in"
+      session[:login] = true
+      if session[:return_to].nil?
+        redirect '/'
+      else
+        redirect session[:return_to]
+      end
+    end
+
+    get '/auth/unathenticated' do
+      session[:login] = false
+      session[:return_to] = env['warden.options'][:attempted_path] if session[:return_to].nil?
+
+      # Set the error and use a fallback if the message is not defined
+      flash[:error] = env['warden.options'][:message] || "You must log in"
+      redirect '/auth/login'
+    end 
+
     get "/" do
+      env['warden'].authenticate!
       @assessments =
         Gitrob::Models::Assessment
         .where(:deleted => false)
@@ -104,6 +176,7 @@ module Gitrob
     end
 
     get "/assessments/_table" do
+      env['warden'].authenticate!
       @assessments =
         Gitrob::Models::Assessment
         .where(:deleted => false)
@@ -133,10 +206,12 @@ module Gitrob
     end
 
     get "/assessments/:id" do
+      env['warden'].authenticate!
       redirect "/assessments/#{params[:id].to_i}/findings"
     end
 
     delete "/assessments/:id" do
+      env['warden'].authenticate!
       @assessment = Gitrob::Models::Assessment.first(
         :id       => params[:id].to_i,
         :deleted  => false
@@ -147,6 +222,7 @@ module Gitrob
     end
 
     get "/assessments/:id/findings" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @findings = @assessment.blobs_dataset.where("flags_count != 0")
         .order(:path).eager(:repository, :flags).all
@@ -154,18 +230,21 @@ module Gitrob
     end
 
     get "/assessments/:id/users" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @owners = @assessment.owners_dataset.order(:type)
       erb :"assessments/users"
     end
 
     get "/assessments/:id/repositories" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @repositories = @assessment.repositories_dataset.order(:full_name).all
       erb :"assessments/repositories"
     end
 
     get "/assessments/:id/compare" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @primary_comparisons = @assessment.primary_comparisons_dataset
                                         .order(:created_at)
@@ -179,6 +258,7 @@ module Gitrob
 
     #Zendesk - Get request for false_positive table
     get "/assessments/:id/false_positives" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @falsePositive = Gitrob::Models::FalsePositive.order(:repository)
       erb :"assessments/false_positive"
@@ -186,6 +266,7 @@ module Gitrob
 
     #Zendesk - Get request for false_positive table
     get "/assessments/:id/:findingID/false_positives" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
 
       @path = Gitrob::Models::Blob.where(:id => params[:findingID]).all
@@ -204,12 +285,14 @@ module Gitrob
 
     #Zendesk - Get request for false_positive table
     get "/falsePositive/_table" do
+      env['warden'].authenticate!
       @falsePositive = Gitrob::Models::FalsePositive.order(:repository)
       erb :"assessments/_falsePositiveTable", :layout => false
     end
 
     #Zendesk - Delete false positive fingerprints
     delete "/false_positive/:id" do
+      env['warden'].authenticate!
       @falsePositive = Gitrob::Models::FalsePositive.first(
         :id       => params[:id].to_i,
       ) || halt(404)
@@ -218,6 +301,7 @@ module Gitrob
 
     #Zendesk - Add new false positive fingerprints
     post "/falsePositive" do
+      env['warden'].authenticate!
       @fingerprint = Gitrob::Models::FalsePositive.new
       @fingerprint.fingerprint = params[:falsePositive][:fingerprint]
       @fingerprint.path = params[:falsePositive][:path]
@@ -226,12 +310,14 @@ module Gitrob
     end
 
     get "/assessments/:id/compare/_comparables" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @assessments = @assessment.comparable_assessments
       erb :"assessments/_comparable_assessments", :layout => false
     end
 
     get "/assessments/:id/compare/_comparisons" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:id])
       @primary_comparisons = @assessment.primary_comparisons_dataset
                                         .order(:created_at)
@@ -243,6 +329,7 @@ module Gitrob
     end
 
     get "/users/:id" do
+      env['warden'].authenticate!
       @owner = Gitrob::Models::Owner.first(:id => params[:id].to_i) || halt(404)
       @assessment = @owner.assessment
       @repositories = @owner.repositories_dataset.order(:name).all
@@ -250,6 +337,7 @@ module Gitrob
     end
 
     get "/repositories/:id" do
+      env['warden'].authenticate!
       @repository = Gitrob::Models::Repository.first(
         :id => params[:id].to_i
       ) || halt(404)
@@ -259,6 +347,7 @@ module Gitrob
     end
 
     get "/blobs/:id" do
+      env['warden'].authenticate!
       @blob = Gitrob::Models::Blob.first(:id => params[:id].to_i) || halt(404)
       @assessment = @blob.assessment
 
@@ -285,6 +374,7 @@ module Gitrob
     end
 
     post "/comparisons" do
+      env['warden'].authenticate!
       @assessment = find_assessment(params[:assessment_id])
       @other_assessment = find_assessment(params[:other_assessment_id])
 
@@ -299,6 +389,7 @@ module Gitrob
     end
 
     get "/comparisons/:id" do
+      env['warden'].authenticate!
       @comparison = find_comparison(params[:id])
       @blobs = @comparison.blobs_dataset.order(:path)
                           .eager(:flags, :repository).all
@@ -308,6 +399,7 @@ module Gitrob
     end
 
     delete "/comparisons/:id" do
+      env['warden'].authenticate!
       @comparison = Gitrob::Models::Comparison.first(
         :id       => params[:id].to_i,
         :deleted  => false

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -31,6 +31,14 @@ footer a {
   text-align: center;
 }
 
+.the-table {
+    table-layout: fixed;
+}
+
+.word-wrap {
+    word-wrap: break-word;
+}
+
 table.assessments td, table.comparisons td {
   text-align: center;
   vertical-align: middle !important;
@@ -68,6 +76,11 @@ table.repositories-table {
 .blob-size {
   text-align: right;
   width: 100px;
+}
+
+.blob-false {
+  text-align: right;
+  width: 50px;
 }
 
 .blob-link {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -17,6 +17,14 @@ $(document).ready(function() {
     }, 5000)
   }
 
+  // Zendesk - initialize False Positive Container
+  if ($("#falsePositive_table_container").length === 1) {
+    initializeFalsePositiveTableEvents();
+    setTimeout(function() {
+      refreshFalsePositiveTable();
+    }, 5000)
+  }
+
   $("#new_assessment_button").on("click", function(e) {
     e.preventDefault();
 
@@ -33,16 +41,25 @@ $(document).ready(function() {
 
   $("#new_assessment_form").on("submit", function(e) {
     e.preventDefault();
-
     $.ajax({
       url: "/assessments",
       type: "POST",
       data: $(this).serialize()
     });
-
     $("#new_assessment_modal").modal("hide");
     refreshAssessmentsTable();
+    return false;
+  });
 
+  // Zendesk - add new false positive submit button event
+  $("#new_falsePositive_form").on("submit", function (e) {
+    e.preventDefault();
+    $.ajax({
+      url: "/falsePositive",
+      type: "POST",
+      data: $(this).serialize()
+    });
+    refreshFalsePositiveTable();
     return false;
   });
 
@@ -157,6 +174,20 @@ function refreshComparisonsTable() {
   }
 }
 
+// Zendesk - refresh table every 5ms
+function refreshFalsePositiveTable() {
+  var refreshEndpoint = $("#falsePositive_table_container").attr("data-refresh-endpoint");
+  if (typeof refreshEndpoint !== typeof undefined && refreshEndpoint !== false) {
+    $.get(refreshEndpoint, function(result) {
+      $("#falsePositive_table_container").html(result);
+      initializeFalsePositiveTableEvents();
+      setTimeout(function() {
+        refreshFalsePositiveTable();
+      }, 5000)
+    });
+  }
+}
+
 function initializeAssessmentsTableEvents() {
   $("table.assessments").on("click", "td.owners", function(e) {
     e.preventDefault();
@@ -192,6 +223,25 @@ function initializeAssessmentsTableEvents() {
     $(this).closest("tr").fadeOut("fast", function() {
       $(this).remove();
     });
+    return false;
+  });
+}
+
+// Zendesk - Initialize the false positive table to allow delete button to work
+function initializeFalsePositiveTableEvents() {
+  $("table.falsePositive").on("click", ".delete-fingerprint", function(e) {
+    e.preventDefault();
+
+    if (confirm("Are you sure you want to delete this fingerprint?")) {
+      $.ajax({
+        url: "/false_positive/" + $(this).attr("data-assessment-id"),
+        type: "DELETE"
+      });
+
+      $(this).closest("tr").fadeOut("fast", function() {
+        $(this).remove();
+      });
+    }
     return false;
   });
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -63,6 +63,19 @@ $(document).ready(function() {
     return false;
   });
 
+  $("#new_login_form").on("submit", function (e) {
+    e.preventDefault();
+    $.ajax({
+      url: "/auth/login",
+      type: "POST",
+      data: $(this).serialize(),
+      success: function(data) {
+        window.location = "/";
+      }
+    });
+    return false;
+  });
+
   $(".blob-link").on("click", function(e) {
     e.preventDefault();
     $("#blob_modal").modal({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
     }, 5000)
   }
 
-  // Zendesk - initialize False Positive Container
+  //Initialize False Positive Container
   if ($("#falsePositive_table_container").length === 1) {
     initializeFalsePositiveTableEvents();
     setTimeout(function() {
@@ -51,7 +51,7 @@ $(document).ready(function() {
     return false;
   });
 
-  // Zendesk - add new false positive submit button event
+  //Add new false positive submit button event
   $("#new_falsePositive_form").on("submit", function (e) {
     e.preventDefault();
     $.ajax({
@@ -187,7 +187,7 @@ function refreshComparisonsTable() {
   }
 }
 
-// Zendesk - refresh table every 5ms
+// Refresh table every 5ms
 function refreshFalsePositiveTable() {
   var refreshEndpoint = $("#falsePositive_table_container").attr("data-refresh-endpoint");
   if (typeof refreshEndpoint !== typeof undefined && refreshEndpoint !== false) {
@@ -240,7 +240,7 @@ function initializeAssessmentsTableEvents() {
   });
 }
 
-// Zendesk - Initialize the false positive table to allow delete button to work
+//Initialize the false positive table to allow delete button to work
 function initializeFalsePositiveTableEvents() {
   $("table.falsePositive").on("click", ".delete-fingerprint", function(e) {
     e.preventDefault();

--- a/views/assessments/_assessments.erb
+++ b/views/assessments/_assessments.erb
@@ -27,7 +27,7 @@
           <% end %>
         <% end %>
       </td>
-      <td><%=h assessment.created_at.strftime("%d-%m-%Y %H:%M") %></td>
+      <td><%=h assessment.created_at.strftime("%Y-%m-%d %H:%M") %></td>
       <td>
         <% if !assessment.finished %>
           <img src="/images/gear_spinner.gif" alt="In progress..." title="In progress..." data-toggle="tooltip" data-placement="bottom" />

--- a/views/assessments/_assessments.erb
+++ b/views/assessments/_assessments.erb
@@ -27,7 +27,7 @@
           <% end %>
         <% end %>
       </td>
-      <td><%=h assessment.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+      <td><%=h assessment.created_at.strftime("%d-%m-%Y %H:%M") %></td>
       <td>
         <% if !assessment.finished %>
           <img src="/images/gear_spinner.gif" alt="In progress..." title="In progress..." data-toggle="tooltip" data-placement="bottom" />

--- a/views/assessments/_falsePositiveTable.erb
+++ b/views/assessments/_falsePositiveTable.erb
@@ -1,0 +1,22 @@
+<table class="table table-hover table-striped table-condensed falsePositive the-table" id="falsePositive_table" data-refresh-endpoint="/falsePositives/_table">
+  <thead>
+    <tr>
+      <th style="width:20%">Repository</th>
+      <th style="width:30%">Path</th>
+      <th style="width:46%">Fingerprint</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @falsePositive.each do |fp| %>
+      <tr>
+        <td class="word-wrap"><%=fp.repository%></td>
+        <td class="word-wrap"><%=fp.path%></td>      
+        <td class="word-wrap"><%=fp.fingerprint%></td>
+        <td>
+          <a class="btn btn-default btn-xs glyphicon glyphicon-trash delete-fingerprint" title="Delete fingerprint" data-toggle="tooltip" data-placement="bottom" href="#" data-assessment-id="<%=h fp.id%>"></a>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/views/assessments/compare.erb
+++ b/views/assessments/compare.erb
@@ -5,6 +5,7 @@
       <li><a href="/assessments/<%=h @assessment.id %>/users"><span class="glyphicon glyphicon-user"></span> Users</a></li>
       <li><a href="/assessments/<%=h @assessment.id %>/repositories"><span class="glyphicon glyphicon-book"></span> Repositories</a></li>
       <li class="active"><a href="/assessments/<%=h @assessment.id %>/compare"><span class="glyphicon glyphicon-eye-open"></span> Compare</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/false_positives"><span class="glyphicon"></span> False Positive</a></li>
     </ul>
   </div>
   <h1>Assessment comparison</h1>

--- a/views/assessments/false_positive.erb
+++ b/views/assessments/false_positive.erb
@@ -1,0 +1,48 @@
+<div class="page-header">
+  <div class="pull-right">
+    <ul class="nav nav-pills">
+      <li><a href="/assessments/<%=h @assessment.id %>/findings"><span class="glyphicon glyphicon-flag"></span> Findings</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/users"><span class="glyphicon glyphicon-user"></span> Users</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/repositories"><span class="glyphicon glyphicon-book"></span> Repositories</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/compare"><span class="glyphicon glyphicon-eye-open"></span> Compare</a></li>
+      <li class="active"><a href="/assessments/<%=h @assessment.id %>/false_positives"><span class="glyphicon"></span> False Positive</a></li>
+    </ul>
+  </div>
+  <h1>Findings</h1>
+</div>
+
+<div id="falsePositive_table_container" data-refresh-endpoint="/falsePositive/_table">
+  <%= erb :"assessments/_falsePositiveTable" %>
+</div>
+
+<form id="new_falsePositive_form">
+  <div class="form-group">
+    <label for="repository">Repository Name</label>
+    <input type="text" class="form-control" id="respository" name="falsePositive[repository]" value="<%=@repo_name%>">
+  </div>
+  <div class="form group">
+    <label for="path">File Path</label>
+    <input type="text" class="form-control" id="path" name="falsePositive[path]" value="<%=@fullpath%>">
+  </div>
+  <div class="form-group">
+    <label for="fingerprint">Fingerprint</label>
+    <input type="text" class="form-control" id="fingerprint" name="falsePositive[fingerprint]" value="<%=@sha256%>">
+  </div>
+  <button type="submit" id="update_falsepositive" class="btn btn-primary">Save</button>
+</form>
+
+
+<div class="modal fade" tabindex="-1" role="dialog" id="blob_modal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content" id="blob_modal_content">
+      <div class="modal-body">
+        <div class="center-text">
+          <img src="/images/blob_spinner.gif" alt="Loading file..." title="Loading file..." />
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/assessments/findings.erb
+++ b/views/assessments/findings.erb
@@ -5,6 +5,7 @@
       <li><a href="/assessments/<%=h @assessment.id %>/users"><span class="glyphicon glyphicon-user"></span> Users</a></li>
       <li><a href="/assessments/<%=h @assessment.id %>/repositories"><span class="glyphicon glyphicon-book"></span> Repositories</a></li>
       <li><a href="/assessments/<%=h @assessment.id %>/compare"><span class="glyphicon glyphicon-eye-open"></span> Compare</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/false_positives"><span class="glyphicon"></span> False Positive</a></li>
     </ul>
   </div>
   <h1>Findings</h1>
@@ -13,30 +14,33 @@
 <table class="table table-striped table-hover table-condensed" id="blobs_table">
   <thead>
     <tr>
-    <th colspan="3">
+    <th colspan="4">
       <div class="pull-right">
         <input type="text" id="quick_filter" class="form-control input-sm quick-filter" placeholder="Quick filter...">
       </div>
     </th>
     </tr>
-    <tr>
-      <th class="blob-path">Path</th>
-      <th class="blob-repo">Repository</th>
-      <th class="blob-size">Size</th>
-    </tr>
   </thead>
   <tbody>
+    <tr>
+      <th>Repository</th>
+      <th>Path</th>      
+      <th>Fingerprint</th>
+      <th>Size</th>
+    </tr>
     <% @findings.each do |finding| %>
       <% if finding.test_blob? %>
         <tr class="blob-row test-blob">
       <% else %>
         <tr class="blob-row">
       <% end %>
-        <td class="blob-path"><a href="/blobs/<%=h finding.id %>" class="blob-link" title="<%=h finding.flags.map(&:caption).join(' - ') %>" data-toggle="tooltip" data-placement="bottom"><%= format_path(finding.path) %></a></td>
         <td class="blob-repo"><a href="/repositories/<%=h finding.repository.id %>"><%=h finding.repository.full_name %></a></td>
+        <td class="blob-path"><a href="/blobs/<%=h finding.id %>" class="blob-link" title="<%=h finding.flags.map(&:caption).join(' - ') %>" data-toggle="tooltip" data-placement="bottom"><%= format_path(finding.path) %></a></td>
+        <td class="blob-fingerprint"><a href="/assessments/<%=h @assessment.id %>/<%=finding.id%>/false_positives"><%= finding.sha256%></a></td>
         <td class="blob-size"><%= number_to_human_size(finding.size) %></td>
-      </tr>
+        </tr>
     <% end %>
+  </tbody>
 </table>
 
 <div class="modal fade" tabindex="-1" role="dialog" id="blob_modal">

--- a/views/assessments/repositories.erb
+++ b/views/assessments/repositories.erb
@@ -5,6 +5,7 @@
       <li><a href="/assessments/<%=h @assessment.id %>/users"><span class="glyphicon glyphicon-user"></span> Users</a></li>
       <li class="active"><a href="/assessments/<%=h @assessment.id %>/repositories"><span class="glyphicon glyphicon-book"></span> Repositories</a></li>
       <li><a href="/assessments/<%=h @assessment.id %>/compare"><span class="glyphicon glyphicon-eye-open"></span> Compare</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/false_positives"><span class="glyphicon"></span> False Positive</a></li>
     </ul>
   </div>
   <h1>Repositories</h1>

--- a/views/assessments/users.erb
+++ b/views/assessments/users.erb
@@ -5,6 +5,7 @@
       <li class="active"><a href="/assessments/<%=h @assessment.id %>/users"><span class="glyphicon glyphicon-user"></span> Users</a></li>
       <li><a href="/assessments/<%=h @assessment.id %>/repositories"><span class="glyphicon glyphicon-book"></span> Repositories</a></li>
       <li><a href="/assessments/<%=h @assessment.id %>/compare"><span class="glyphicon glyphicon-eye-open"></span> Compare</a></li>
+      <li><a href="/assessments/<%=h @assessment.id %>/false_positives"><span class="glyphicon"></span> False Positive</a></li>
     </ul>
   </div>
   <h1>Users</h1>

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -1,0 +1,5 @@
+<form id="new_login_form" method="post">
+  <p>Username: <input type="text" name="user[username]" /></p>
+  <p>Password: <input type="password" name="user[password]" /></p>
+  <button type="submit" id="login" value = "Log In" class="btn btn-primary">Log In</button>
+</form>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,3 +1,10 @@
+<div class="page-header">
+  <h1>
+  <button type="button" class="pull-right btn btn-success" id="new_assessment_button"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> New assessment</button>
+  Assessments
+  </h1>
+</div>
+
 <div id="assessments_table_container" data-refresh-endpoint="/assessments/_table">
   <%= erb :"assessments/_assessments" %>
 </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,10 +1,3 @@
-<div class="page-header">
-  <h1>
-  <button type="button" class="pull-right btn btn-success" id="new_assessment_button"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> New assessment</button>
-  Assessments
-  </h1>
-</div>
-
 <div id="assessments_table_container" data-refresh-endpoint="/assessments/_table">
   <%= erb :"assessments/_assessments" %>
 </div>
@@ -33,7 +26,7 @@
             </div>
             <div class="form-group">
               <label for="assessment_github_access_tokens">GitHub API access tokens <small>(one per line)</small></label>
-              <textarea class="form-control" id="assessment_github_access_tokens" name="assessment[github_access_tokens]" rows="3"><%=h Gitrob::CLI.configuration["github_access_tokens"].join("\n") %></textarea>
+              <textarea class="form-control" id="assessment_github_access_tokens" name="assessment[github_access_tokens]" rows="3"></textarea>
             </div>
           </form>
         </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -14,7 +14,18 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   </head>
-  <body>
+  <body>   
+    <% if flash[:success] %>
+    <div style="color:green;">
+      <%= flash[:success] %>
+    </div>
+    <% end %>
+
+    <% if flash[:error] %>
+    <div style="color:red;">
+      <%= flash[:error] %>
+    </div>
+    <% end %>
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <div class="navbar-header">
@@ -30,6 +41,11 @@
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
             <li><a href="/">Assessments</a></li>
+            <% if session[:login] == true %>
+              <li><a href="/auth/logout">Log Out</a></li>
+            <% elsif session[:login] == false %>
+              <li><a href="/auth/login">Log In</a></li>
+            <% end %>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
### Enhancement
1. Added false positive handling to avoid detection on the next run. SHA256 is generated from commit hash, file path, owner name and repository name. 
1.1 Clicking on the file fingerprint will autofill the false positive form to include that particular fingerprint into the false positive set.
<img width="1200" alt="screen shot 2017-07-05 at 3 11 44 pm" src="https://user-images.githubusercontent.com/21576892/27853221-82de187a-6194-11e7-8692-02099e78d9aa.png">
<img width="1215" alt="screen shot 2017-07-05 at 3 12 26 pm" src="https://user-images.githubusercontent.com/21576892/27853231-88e54e8c-6194-11e7-986f-ed5047f6b574.png">

2. Added authentication to only allow authenticated users to view Gitrob results.
2.1 Login credentials will be generated during Gitrob first run. 
<img width="431" alt="screen shot 2017-07-05 at 3 23 32 pm" src="https://user-images.githubusercontent.com/21576892/27853604-f1a31f5c-6195-11e7-9ce9-f426b9a38026.png">
<img width="328" alt="screen shot 2017-07-05 at 3 24 26 pm" src="https://user-images.githubusercontent.com/21576892/27853656-245095ba-6196-11e7-9a6b-c44d29122d7a.png">

3. Added rate limiting by limiting Github client call to avoid hitting Github API rate limit if limited API keys available

4. Added an option to disable organization member scan to reduce noise and focus on organization repo only. 