### PR TITLE
Load configuration from environment variables

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec ./exe/gitrob server --bind-address "0.0.0.0"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Gitrob needs to know how to talk to the PostgreSQL database as well as what acce
 
 The configuration wizard will ask you for the information needed to set up Gitrob. All the information is saved to `~/.gitrobrc` and yes, Gitrob will be looking for this file too, so watch out!
 
+#### Environment Variables
+
+Gitrob can also be configured using the following environment variables:
+
+ * **ACCEPT_TOS**: Setting any value will accept the terms of service.
+ * **PORT**: The port gitrob will listen on.
+ * **DATABASE_URL**: URL containing the credentials and hostname of the database server.
+ * **GITHUB_TOKEN**: [Github access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+
+
 ## Usage
 
 ### Analyzing organizations and users

--- a/lib/gitrob/cli.rb
+++ b/lib/gitrob/cli.rb
@@ -22,7 +22,7 @@ module Gitrob
                  :desc    => "Address to bind web server to"
     class_option :port,
                  :type    => :numeric,
-                 :default => 9393,
+                 :default => ENV['PORT'].to_i || 9393,
                  :desc    => "Port to run web server on"
     class_option :access_tokens,
                  :type    => :string,

--- a/lib/gitrob/cli/commands/accept_terms_of_use.rb
+++ b/lib/gitrob/cli/commands/accept_terms_of_use.rb
@@ -30,7 +30,7 @@ module Gitrob
         private
 
         def terms_of_use_accepted?
-          File.exist?(AGREEMENT_FILE_PATH)
+          ENV.include?("ACCEPT_TOS") || File.exist?(AGREEMENT_FILE_PATH)
         end
 
         def present_terms_of_use

--- a/lib/gitrob/cli/commands/configure.rb
+++ b/lib/gitrob/cli/commands/configure.rb
@@ -20,10 +20,16 @@ module Gitrob
         end
 
         def self.configured?
-          File.exist?(CONFIGURATION_FILE_PATH)
+          environment_configured? || File.exist?(CONFIGURATION_FILE_PATH)
         end
 
         def self.load_configuration!
+          if environment_configured?
+            return {
+              "sql_connection_uri"   => ENV['DATABASE_URL'],
+              "github_access_tokens" => [ENV['GITHUB_TOKEN']],
+            }
+          end
           fail ConfigurationFileNotFound \
             unless File.exist?(CONFIGURATION_FILE_PATH)
           fail ConfigurationFileNotReadable \
@@ -31,6 +37,10 @@ module Gitrob
           YAML.load(File.read(CONFIGURATION_FILE_PATH))
         rescue Psych::SyntaxError
           raise ConfigurationFileCorrupt
+        end
+
+        def self.environment_configured?
+          ENV.include?("PORT") && ENV.include?("DATABASE_URL") && ENV.include?("GITHUB_TOKEN")
         end
 
         private


### PR DESCRIPTION
These changes make it easy to run Gitrob on a PaaS such as Heroku.

Currently only a single github token can be specified when configuring
using environment variables.