### PR TITLE
Add size check signature

### DIFF
--- a/signatures.json
+++ b/signatures.json
@@ -551,5 +551,11 @@
     "pattern": "\\A\\.?env\\z",
     "caption": "Environment configuration file",
     "description": null
+  },
+  {
+    "type": "size",
+    "greater_than": "10000000",
+    "caption": "File over 10MB",
+    "description": "May be an accidental information disclosure"
   }
 ]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -69,7 +69,7 @@ FactoryGirl.define do
       ext = %w(sql rb py php go txt md).sample
       "#{dir.join('/')}/#{file}.#{ext}"
     end
-    size { Faker::Number.number(5) }
+    size { Faker::Number.number(3) }
     sha { Digest::SHA1.hexdigest(Random.rand.to_s) }
   end
 


### PR DESCRIPTION
Since it's (typically) uncommon for large binaries to be stored in
repositories. If a large file has been commited there is a chance it was
mistaken and could be an accidental information disclosure.

Since the size check doesn't conform to the pattern of other signatures
it means the signature validation functions have been relaxed.