### PR TITLE
Fix edge case where sess.Repositories=0

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func AnalyzeRepositories(sess *core.Session) {
   var ch = make(chan *core.GithubRepository, len(sess.Repositories))
   var wg sync.WaitGroup
   var threadNum int
-  if len(sess.Repositories) == 1 {
+  if len(sess.Repositories) <= 1 {
     threadNum = 1
   } else if len(sess.Repositories) <= *sess.Options.Threads {
     threadNum = len(sess.Repositories) - 1


### PR DESCRIPTION
When `gatherRepositories` can't find any repositories, the `analyzeRepositories` throws a runtime error:

```
root@45fc46e07394:/go/src# gitrob XXX
        _ __           __
  ___ _(_) /________  / /
 / _ `/ / __/ __/ _ \/ _ \
 \_, /_/\__/_/  \___/_.__/
/___/ by @michenriksen

gitrob v2.0.0-beta started at 2018-06-29T08:30:24Z
Loaded 91 signatures
Web interface available at http://0.0.0.0:8000
Gathering targets...
panic: sync: negative WaitGroup counter

goroutine 1 [running]:
sync.(*WaitGroup).Add(0xc420409010, 0xffffffffffffffff)
	/usr/local/go/src/sync/waitgroup.go:73 +0x133
main.AnalyzeRepositories(0xc420172800)
	/go/src/github.com/michenriksen/gitrob/main.go:101 +0xd4
main.main()
	/go/src/github.com/michenriksen/gitrob/main.go:232 +0x42c
```

The problem is contained in the following lines (taken from `main.go`):

```
if len(sess.Repositories) == 1 {
	threadNum = 1
} else if len(sess.Repositories) <= *sess.Options.Threads {
	threadNum = len(sess.Repositories) - 1
} else {
	threadNum = *sess.Options.Threads
}
```

In this particular case `len(sess.Repositories)` is `0`, therefore at the end of the snippet we will have selected a negative number of threads.

This is easily fixed with this PR.