### PR TITLE
Fetching Organization Private Repos

### DIFF
--- a/core/github.go
+++ b/core/github.go
@@ -1,113 +1,151 @@
 package core
 
 import (
-  "context"
+	"context"
 
-  "github.com/google/go-github/github"
+	"github.com/google/go-github/github"
 )
 
 type GithubOwner struct {
-  Login     *string
-  ID        *int64
-  Type      *string
-  Name      *string
-  AvatarURL *string
-  URL       *string
-  Company   *string
-  Blog      *string
-  Location  *string
-  Email     *string
-  Bio       *string
+	Login     *string
+	ID        *int64
+	Type      *string
+	Name      *string
+	AvatarURL *string
+	URL       *string
+	Company   *string
+	Blog      *string
+	Location  *string
+	Email     *string
+	Bio       *string
 }
 
 type GithubRepository struct {
-  Owner         *string
-  ID            *int64
-  Name          *string
-  FullName      *string
-  CloneURL      *string
-  URL           *string
-  DefaultBranch *string
-  Description   *string
-  Homepage      *string
+	Owner         *string
+	ID            *int64
+	Name          *string
+	FullName      *string
+	CloneURL      *string
+	URL           *string
+	DefaultBranch *string
+	Description   *string
+	Homepage      *string
 }
 
 func GetUserOrOrganization(login string, client *github.Client) (*GithubOwner, error) {
-  ctx := context.Background()
-  user, _, err := client.Users.Get(ctx, login)
-  if err != nil {
-    return nil, err
-  }
-  return &GithubOwner{
-    Login:     user.Login,
-    ID:        user.ID,
-    Type:      user.Type,
-    Name:      user.Name,
-    AvatarURL: user.AvatarURL,
-    URL:       user.HTMLURL,
-    Company:   user.Company,
-    Blog:      user.Blog,
-    Location:  user.Location,
-    Email:     user.Email,
-    Bio:       user.Bio,
-  }, nil
+	ctx := context.Background()
+	user, _, err := client.Users.Get(ctx, login)
+	if err != nil {
+		return nil, err
+	}
+	return &GithubOwner{
+		Login:     user.Login,
+		ID:        user.ID,
+		Type:      user.Type,
+		Name:      user.Name,
+		AvatarURL: user.AvatarURL,
+		URL:       user.HTMLURL,
+		Company:   user.Company,
+		Blog:      user.Blog,
+		Location:  user.Location,
+		Email:     user.Email,
+		Bio:       user.Bio,
+	}, nil
 }
 
 func GetRepositoriesFromOwner(login *string, client *github.Client) ([]*GithubRepository, error) {
-  var allRepos []*GithubRepository
-  loginVal := *login
-  ctx := context.Background()
-  opt := &github.RepositoryListOptions{
-    Type: "sources",
-  }
+	var allRepos []*GithubRepository
+	loginVal := *login
+	ctx := context.Background()
+	opt := &github.RepositoryListOptions{
+		Type: "sources",
+	}
 
-  for {
-    repos, resp, err := client.Repositories.List(ctx, loginVal, opt)
-    if err != nil {
-      return allRepos, err
-    }
-    for _, repo := range repos {
-      if !*repo.Fork {
-        r := GithubRepository{
-          Owner:         repo.Owner.Login,
-          ID:            repo.ID,
-          Name:          repo.Name,
-          FullName:      repo.FullName,
-          CloneURL:      repo.CloneURL,
-          URL:           repo.HTMLURL,
-          DefaultBranch: repo.DefaultBranch,
-          Description:   repo.Description,
-          Homepage:      repo.Homepage,
-        }
-        allRepos = append(allRepos, &r)
-      }
-    }
-    if resp.NextPage == 0 {
-      break
-    }
-    opt.Page = resp.NextPage
-  }
+	for {
+		repos, resp, err := client.Repositories.List(ctx, loginVal, opt)
+		if err != nil {
+			return allRepos, err
+		}
+		for _, repo := range repos {
+			if !*repo.Fork {
+				r := GithubRepository{
+					Owner:         repo.Owner.Login,
+					ID:            repo.ID,
+					Name:          repo.Name,
+					FullName:      repo.FullName,
+					CloneURL:      repo.CloneURL,
+					URL:           repo.HTMLURL,
+					DefaultBranch: repo.DefaultBranch,
+					Description:   repo.Description,
+					Homepage:      repo.Homepage,
+				}
+				allRepos = append(allRepos, &r)
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
 
-  return allRepos, nil
+	return allRepos, nil
+}
+
+func GetRepositoriesFromOrganization(login *string, client *github.Client) ([]*GithubRepository, error) {
+	var allRepos []*GithubRepository
+	loginVal := *login
+	ctx := context.Background()
+	opt := &github.RepositoryListByOrgOptions{
+		Type: "sources",
+	}
+
+	for {
+		repos, resp, err := client.Repositories.ListByOrg(ctx, loginVal, opt)
+		if err != nil {
+			return allRepos, err
+		}
+		for _, repo := range repos {
+			if !*repo.Fork {
+				r := GithubRepository{
+					Owner:         repo.Owner.Login,
+					ID:            repo.ID,
+					Name:          repo.Name,
+					FullName:      repo.FullName,
+					CloneURL:      repo.SSHURL,
+					URL:           repo.HTMLURL,
+					DefaultBranch: repo.DefaultBranch,
+					Description:   repo.Description,
+					Homepage:      repo.Homepage,
+				}
+				allRepos = append(allRepos, &r)
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	return allRepos, nil
 }
 
 func GetOrganizationMembers(login *string, client *github.Client) ([]*GithubOwner, error) {
-  var allMembers []*GithubOwner
-  loginVal := *login
-  ctx := context.Background()
-  opt := &github.ListMembersOptions{}
-  for {
-    members, resp, err := client.Organizations.ListMembers(ctx, loginVal, opt)
-    if err != nil {
-      return allMembers, err
-    }
-    for _, member := range members {
-      allMembers = append(allMembers, &GithubOwner{Login: member.Login, ID: member.ID, Type: member.Type})
-    }
-    if resp.NextPage == 0 {
-      break
-    }
-    opt.Page = resp.NextPage
-  }
-  return allMembers, nil
+	var allMembers []*GithubOwner
+	loginVal := *login
+	ctx := context.Background()
+	opt := &github.ListMembersOptions{}
+	for {
+		members, resp, err := client.Organizations.ListMembers(ctx, loginVal, opt)
+		if err != nil {
+			return allMembers, err
+		}
+		for _, member := range members {
+			allMembers = append(allMembers, &GithubOwner{Login: member.Login, ID: member.ID, Type: member.Type})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+	return allMembers, nil
 }

--- a/main.go
+++ b/main.go
@@ -57,12 +57,18 @@ func GatherRepositories(sess *core.Session) {
   for i := 0; i < threadNum; i++ {
     go func() {
       for {
+        var repos []*core.GithubRepository
+	var err error
         target, ok := <-ch
         if !ok {
           wg.Done()
           return
         }
-        repos, err := core.GetRepositoriesFromOwner(target.Login, sess.GithubClient)
+	if *target.Type == "Organization" {
+		repos, err = core.GetRepositoriesFromOrganization(target.Login, sess.GithubClient)
+	} else {
+		repos, err = core.GetRepositoriesFromOwner(target.Login, sess.GithubClient)
+	}
         if err != nil {
           sess.Out.Error(" Failed to retrieve repositories from %s: %s\n", *target.Login, err)
         }


### PR DESCRIPTION
As discussed in Issue #76 the current version of GitRob is not able to fetch private repositories of organizations.

This patch adds a new function that uses the _GitHub API_ method `Repositories.ListByOrg` to retrieve a list of all the repositories from an organization including the private ones if the access token given has access to them.

After that, the `CloneURL` is set to the `SSHURL` attribute of the GitHub object , allowing the cloning of the repositories over ssh. In the future it's possible to check if the repository is public before setting the `CloneURL`, if _public_ keeps using the _HTTTPS URL_, otherwise uses the _SSHURL_ instead.
The selection of what function to use is based on the _target_ type.

The command `go fmt` was ran on the `core/github.go` file, that's why the diff is showing so many modifications.

Added function GetRepositoriesFromOrganization for downloading of
private repo when target is an Organization using SSH URL
```

diff --git a/core/github.go b/core/github.go
index a194170..a32552b 100644
--- a/core/github.go
+++ b/core/github.go
@@ -91,6 +91,44 @@ func GetRepositoriesFromOwner(login *string, client *github.Client) ([]*GithubRe
        return allRepos, nil
 }

+func GetRepositoriesFromOrganization(login *string, client *github.Client) ([]*GithubRepository, error) {
+       var allRepos []*GithubRepository
+       loginVal := *login
+       ctx := context.Background()
+       opt := &github.RepositoryListByOrgOptions{
+               Type: "sources",
+       }
+
+       for {
+               repos, resp, err := client.Repositories.ListByOrg(ctx, loginVal, opt)
+               if err != nil {
+                       return allRepos, err
+               }
+               for _, repo := range repos {
+                       if !*repo.Fork {
+                               r := GithubRepository{
+                                       Owner:         repo.Owner.Login,
+                                       ID:            repo.ID,
+                                       Name:          repo.Name,
+                                       FullName:      repo.FullName,
+                                       CloneURL:      repo.SSHURL,
+                                       URL:           repo.HTMLURL,
+                                       DefaultBranch: repo.DefaultBranch,
+                                       Description:   repo.Description,
+                                       Homepage:      repo.Homepage,
+                               }
+                               allRepos = append(allRepos, &r)
+                       }
+               }
+               if resp.NextPage == 0 {
+                       break
+               }
+               opt.Page = resp.NextPage
+       }
+
+       return allRepos, nil
+}
+
 func GetOrganizationMembers(login *string, client *github.Client) ([]*GithubOwner, error) {
        var allMembers []*GithubOwner
        loginVal := *login
diff --git a/main.go b/main.go
--- a/main.go
+++ b/main.go
@@ -57,12 +57,18 @@ func GatherRepositories(sess *core.Session) {
   for i := 0; i < threadNum; i++ {
     go func() {
       for {
+        var repos []*core.GithubRepository
+       var err error
         target, ok := <-ch
         if !ok {
           wg.Done()
           return
         }
-        repos, err := core.GetRepositoriesFromOwner(target.Login, sess.GithubClient)
+       if *target.Type == "Organization" {
+               repos, err = core.GetRepositoriesFromOrganization(target.Login, sess.GithubClient)
+       } else {
+               repos, err = core.GetRepositoriesFromOwner(target.Login, sess.GithubClient)
+       }
         if err != nil {
           sess.Out.Error(" Failed to retrieve repositories from %s: %s\n", *target.Login, err)
         }



```