### PR TITLE
Add `-no-server` switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Gitrob is a tool to help find potentially sensitive files pushed to public repos
     Load session file
 -no-expand-orgs
     Don't add members to targets when processing organizations
+-no-server
+    Disables web server
 -port int
     Port to run web server on (default 9393)
 -save string

--- a/core/options.go
+++ b/core/options.go
@@ -15,6 +15,7 @@ type Options struct {
   Port              *int
   Silent            *bool
   Debug             *bool
+  NoServer          *bool
   Logins            []string
 }
 
@@ -30,6 +31,7 @@ func ParseOptions() (Options, error) {
     Port:              flag.Int("port", 9393, "Port to run web server on"),
     Silent:            flag.Bool("silent", false, "Suppress all output except for errors"),
     Debug:             flag.Bool("debug", false, "Print debugging information"),
+    NoServer:          flag.Bool("no-server", false, "Disables web server"),
   }
 
   flag.Parse()

--- a/core/session.go
+++ b/core/session.go
@@ -60,7 +60,9 @@ func (s *Session) Start() {
   s.InitThreads()
   s.InitGithubAccessToken()
   s.InitGithubClient()
-  s.InitRouter()
+  if !*s.Options.NoServer {
+    s.InitRouter()
+  }
 }
 
 func (s *Session) Finish() {

--- a/main.go
+++ b/main.go
@@ -218,7 +218,9 @@ func main() {
   sess.Out.Info("%s\n\n", core.ASCIIBanner)
   sess.Out.Important("%s v%s started at %s\n", core.Name, core.Version, sess.Stats.StartedAt.Format(time.RFC3339))
   sess.Out.Important("Loaded %d signatures\n", len(core.Signatures))
-  sess.Out.Important("Web interface available at http://%s:%d\n", *sess.Options.BindAddress, *sess.Options.Port)
+  if !*sess.Options.NoServer {
+    sess.Out.Important("Web interface available at http://%s:%d\n", *sess.Options.BindAddress, *sess.Options.Port)
+  }
 
   if sess.Stats.Status == "finished" {
     sess.Out.Important("Loaded session file: %s\n", *sess.Options.Load)
@@ -242,6 +244,8 @@ func main() {
   }
 
   PrintSessionStats(sess)
-  sess.Out.Important("Press Ctrl+C to stop web server and exit.\n\n")
-  select {}
+  if !*sess.Options.NoServer {
+    sess.Out.Important("Press Ctrl+C to stop web server and exit.\n\n")
+    select {}
+  }
 }


### PR DESCRIPTION
Added option to stop *gitrob* from starting its own web server so it is possible to just get findings.

**Closing issues**

Closes #142

