### PR TITLE
Add `-include-forks` switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Gitrob is a tool to help find potentially sensitive files pushed to public repos
     Print debugging information
 -github-access-token string
     GitHub access token to use for API requests
+-include-forks
+    Include forked repositories in scan
 -load string
     Load session file
 -no-expand-orgs

--- a/core/github.go
+++ b/core/github.go
@@ -53,7 +53,7 @@ func GetUserOrOrganization(login string, client *github.Client) (*GithubOwner, e
   }, nil
 }
 
-func GetRepositoriesFromOwner(login *string, client *github.Client) ([]*GithubRepository, error) {
+func GetRepositoriesFromOwner(login *string, client *github.Client, includeForks *bool) ([]*GithubRepository, error) {
   var allRepos []*GithubRepository
   loginVal := *login
   ctx := context.Background()
@@ -67,7 +67,7 @@ func GetRepositoriesFromOwner(login *string, client *github.Client) ([]*GithubRe
       return allRepos, err
     }
     for _, repo := range repos {
-      if !*repo.Fork {
+      if (*includeForks && *repo.Fork) || !*repo.Fork {
         r := GithubRepository{
           Owner:         repo.Owner.Login,
           ID:            repo.ID,

--- a/core/options.go
+++ b/core/options.go
@@ -15,6 +15,7 @@ type Options struct {
   Port              *int
   Silent            *bool
   Debug             *bool
+  IncludeForks      *bool
   Logins            []string
 }
 
@@ -30,6 +31,7 @@ func ParseOptions() (Options, error) {
     Port:              flag.Int("port", 9393, "Port to run web server on"),
     Silent:            flag.Bool("silent", false, "Suppress all output except for errors"),
     Debug:             flag.Bool("debug", false, "Print debugging information"),
+    IncludeForks:      flag.Bool("include-forks", false, "Include forked repositories in scan"),
   }
 
   flag.Parse()

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func GatherRepositories(sess *core.Session) {
           wg.Done()
           return
         }
-        repos, err := core.GetRepositoriesFromOwner(target.Login, sess.GithubClient)
+        repos, err := core.GetRepositoriesFromOwner(target.Login, sess.GithubClient, sess.Options.IncludeForks)
         if err != nil {
           sess.Out.Error(" Failed to retrieve repositories from %s: %s\n", *target.Login, err)
         }


### PR DESCRIPTION
Adding command line switch `-include-forks` to toggle behavior to include repositories that orignate as forks in an organization to be scanned by *gitrob*

**Closing issues**

closes #157 