### PR TITLE
✨ Add support for Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Gitrob will start its web interface and serve the results for analysis.
 
 To configure Gitrob for Github Enterprise, the following switches can be used:
 
-- `enterprise-url`: Must be specified; this is the URL where the path `/api/v3/` exists. This is usually the URL where the Github Webinterface can be found. Example: `-enterprise-url=https://github.yourcompany.com`
+- `enterprise-url`: Must be specified; this is the URL where the path `/api/v3/` exists. This is usually the URL where the Github web interface can be found. Example: `-enterprise-url=https://github.yourcompany.com`
 - `enterprise-upload-url:` Optional, defaults to `enterprise-url`; full path to the upload URL if different from the main Github Enterprise URL. Example: `-enterprise-upload-url=https://github.yourcompany.com/api/v3/upload`
 - `enterprise-user`: Optional, defaults to the first target. Example: `-enterprise-user=your.username`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Gitrob is a tool to help find potentially sensitive files pushed to public repos
     Number of repository commits to process (default 500)
 -debug
     Print debugging information
+-enterprise-upload-url string
+    Upload URL for Github Enterprise (defaults to the URL set in -enterprise-url if any)
+-enterprise-url string
+    URL for Github Enterprise (/api/v3/ will be appended if not included)
+-enterprise-user string
+    Username for Github Enterprise (defaults to first target)
 -github-access-token string
     GitHub access token to use for API requests
 -load string
@@ -53,6 +59,14 @@ A session stored in a file can be loaded with the `-load` option:
     gitrob -load ~/gitrob-session.json
 
 Gitrob will start its web interface and serve the results for analysis.
+
+### Use with Github Enterprise
+
+To configure Gitrob for Github Enterprise, the following switches can be used:
+
+- `enterprise-url`: Must be specified; this is the URL where the path `/api/v3/` exists. This is usually the URL where the Github Webinterface can be found.
+- `enterprise-upload-url:` Optional, defaults to `enterprise-url`; full path to the upload URL if different from the main Github Enterprise URL.
+- `enterprise-user`: Optional, defaults to the first target.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Gitrob is a tool to help find potentially sensitive files pushed to public repos
 -enterprise-upload-url string
     Upload URL for Github Enterprise (defaults to the URL set in -enterprise-url if any)
 -enterprise-url string
-    URL for Github Enterprise (/api/v3/ will be appended if not included)
+    URL for Github Enterprise
 -enterprise-user string
     Username for Github Enterprise (defaults to first target)
 -github-access-token string
@@ -64,9 +64,9 @@ Gitrob will start its web interface and serve the results for analysis.
 
 To configure Gitrob for Github Enterprise, the following switches can be used:
 
-- `enterprise-url`: Must be specified; this is the URL where the path `/api/v3/` exists. This is usually the URL where the Github Webinterface can be found.
-- `enterprise-upload-url:` Optional, defaults to `enterprise-url`; full path to the upload URL if different from the main Github Enterprise URL.
-- `enterprise-user`: Optional, defaults to the first target.
+- `enterprise-url`: Must be specified; this is the URL where the path `/api/v3/` exists. This is usually the URL where the Github Webinterface can be found. Example: `-enterprise-url=https://github.yourcompany.com`
+- `enterprise-upload-url:` Optional, defaults to `enterprise-url`; full path to the upload URL if different from the main Github Enterprise URL. Example: `-enterprise-upload-url=https://github.yourcompany.com/api/v3/upload`
+- `enterprise-user`: Optional, defaults to the first target. Example: `-enterprise-user=your.username`
 
 ## Installation
 

--- a/core/git.go
+++ b/core/git.go
@@ -7,6 +7,7 @@ import (
   "gopkg.in/src-d/go-git.v4"
   "gopkg.in/src-d/go-git.v4/plumbing"
   "gopkg.in/src-d/go-git.v4/plumbing/object"
+  "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
   "gopkg.in/src-d/go-git.v4/utils/merkletrie"
 )
 
@@ -14,20 +15,27 @@ const (
   EmptyTreeCommitId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 )
 
-func CloneRepository(url *string, branch *string, depth int) (*git.Repository, string, error) {
+func CloneRepository(url *string, branch *string, sess *Session) (*git.Repository, string, error) {
   urlVal := *url
   branchVal := *branch
   dir, err := ioutil.TempDir("", "gitrob")
   if err != nil {
     return nil, "", err
   }
-  repository, err := git.PlainClone(dir, false, &git.CloneOptions{
-    URL:           urlVal,
-    Depth:         depth,
+  
+  options := &git.CloneOptions{
+	URL:           urlVal,
+    Depth:         *sess.Options.CommitDepth,
     ReferenceName: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branchVal)),
     SingleBranch:  true,
     Tags:          git.NoTags,
-  })
+  }
+
+  if sess.GithubAccessToken != "" && *sess.Options.EnterpriseUser != "" {
+    options.Auth = &http.BasicAuth{Username: *sess.Options.EnterpriseUser, Password: sess.GithubAccessToken}
+  }
+ 
+  repository, err := git.PlainClone(dir, false, options)
   if err != nil {
     return nil, dir, err
   }

--- a/core/git.go
+++ b/core/git.go
@@ -24,7 +24,7 @@ func CloneRepository(url *string, branch *string, sess *Session) (*git.Repositor
   }
   
   options := &git.CloneOptions{
-	URL:           urlVal,
+    URL:           urlVal,
     Depth:         *sess.Options.CommitDepth,
     ReferenceName: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branchVal)),
     SingleBranch:  true,

--- a/core/options.go
+++ b/core/options.go
@@ -7,6 +7,7 @@ import (
 type Options struct {
   CommitDepth       *int
   GithubAccessToken *string `json:"-"`
+  EnterpriseURL     *string
   EnterpriseAPI     *string
   EnterpriseUpload  *string
   EnterpriseUser    *string
@@ -24,9 +25,9 @@ type Options struct {
 func ParseOptions() (Options, error) {
   options := Options{
     CommitDepth:       flag.Int("commit-depth", 500, "Number of repository commits to process"),
-	GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
-    EnterpriseAPI:     flag.String("enterprise-url", "", "Base URL of the GitHub Enterprise API"),
-    EnterpriseUpload:  flag.String("enterprise-upload-url", "", "Upload URL for GitHub Enterprise"),
+	  GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
+    EnterpriseURL:     flag.String("enterprise-url", "", "URL of the GitHub Enterprise instance, e.g. https://github.yourcompany.com"),
+    EnterpriseUpload:  flag.String("enterprise-upload-url", "", "Upload URL for GitHub Enterprise, e.g. https://github.yourcompany.com/api/v3/upload"),
     EnterpriseUser:    flag.String("enterprise-user", "", "Username for your GitHub Enterprise account"),
     NoExpandOrgs:      flag.Bool("no-expand-orgs", false, "Don't add members to targets when processing organizations"),
     Threads:           flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)"),

--- a/core/options.go
+++ b/core/options.go
@@ -25,7 +25,7 @@ type Options struct {
 func ParseOptions() (Options, error) {
   options := Options{
     CommitDepth:       flag.Int("commit-depth", 500, "Number of repository commits to process"),
-	  GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
+    GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
     EnterpriseURL:     flag.String("enterprise-url", "", "URL of the GitHub Enterprise instance, e.g. https://github.yourcompany.com"),
     EnterpriseUpload:  flag.String("enterprise-upload-url", "", "Upload URL for GitHub Enterprise, e.g. https://github.yourcompany.com/api/v3/upload"),
     EnterpriseUser:    flag.String("enterprise-user", "", "Username for your GitHub Enterprise account"),

--- a/core/options.go
+++ b/core/options.go
@@ -7,6 +7,9 @@ import (
 type Options struct {
   CommitDepth       *int
   GithubAccessToken *string `json:"-"`
+  EnterpriseAPI     *string
+  EnterpriseUpload  *string
+  EnterpriseUser    *string
   NoExpandOrgs      *bool
   Threads           *int
   Save              *string `json:"-"`
@@ -21,7 +24,10 @@ type Options struct {
 func ParseOptions() (Options, error) {
   options := Options{
     CommitDepth:       flag.Int("commit-depth", 500, "Number of repository commits to process"),
-    GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
+	GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
+    EnterpriseAPI:     flag.String("enterprise-url", "", "Base URL of the GitHub Enterprise API"),
+    EnterpriseUpload:  flag.String("enterprise-upload-url", "", "Upload URL for GitHub Enterprise"),
+    EnterpriseUser:    flag.String("enterprise-user", "", "Username for your GitHub Enterprise account"),
     NoExpandOrgs:      flag.Bool("no-expand-orgs", false, "Don't add members to targets when processing organizations"),
     Threads:           flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)"),
     Save:              flag.String("save", "", "Save session to file"),

--- a/core/signatures.go
+++ b/core/signatures.go
@@ -59,8 +59,8 @@ type Finding struct {
   RepositoryUrl   string
 }
 
-func (f *Finding) setupUrls() {
-  f.RepositoryUrl = fmt.Sprintf("https://github.com/%s/%s", f.RepositoryOwner, f.RepositoryName)
+func (f *Finding) setupUrls(githubURL string) {
+  f.RepositoryUrl = strings.Join([]string {githubURL, f.RepositoryOwner, f.RepositoryName}, "/")
   f.FileUrl = fmt.Sprintf("%s/blob/%s/%s", f.RepositoryUrl, f.CommitHash, f.FilePath)
   f.CommitUrl = fmt.Sprintf("%s/commit/%s", f.RepositoryUrl, f.CommitHash)
 }
@@ -77,8 +77,8 @@ func (f *Finding) generateID() {
   f.Id = fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func (f *Finding) Initialize() {
-  f.setupUrls()
+func (f *Finding) Initialize(githubURL string) {
+  f.setupUrls(githubURL)
   f.generateID()
 }
 

--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func AnalyzeRepositories(sess *core.Session) {
 
   sess.Out.Important("Analyzing %d %s...\n", len(sess.Repositories), core.Pluralize(len(sess.Repositories), "repository", "repositories"))
 
+  githubURL := sess.GithubURL()
+
   for i := 0; i < threadNum; i++ {
     go func(tid int) {
       for {
@@ -163,7 +165,7 @@ func AnalyzeRepositories(sess *core.Session) {
                   CommitMessage:   strings.TrimSpace(commit.Message),
                   CommitAuthor:    commit.Author.String(),
                 }
-                finding.Initialize()
+                finding.Initialize(githubURL)
                 sess.AddFinding(finding)
 
                 sess.Out.Warn(" %s: %s\n", strings.ToUpper(changeAction), finding.Description)

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func AnalyzeRepositories(sess *core.Session) {
         }
 
         sess.Out.Debug("[THREAD #%d][%s] Cloning repository...\n", tid, *repo.FullName)
-        clone, path, err := core.CloneRepository(repo.CloneURL, repo.DefaultBranch, *sess.Options.CommitDepth)
+        clone, path, err := core.CloneRepository(repo.CloneURL, repo.DefaultBranch, sess)
         if err != nil {
           if err.Error() != "remote repository is empty" {
             sess.Out.Error("Error cloning repository %s: %s\n", *repo.FullName, err)


### PR DESCRIPTION
This adds support for GitHub Enterprise which can be configured using the three new command line arguments with the enterprise prefix (see documentation).

The URL of the Github Enterprise installation (`-enterprise-url`) must be specified. The username _should_ be specified (`-enterprise-user`, defaults to the first target). Depending on the configuration of the Github Enterprise instance, the upload URL must be specified (`-enterprise-upload-url`) if it differs from the main URL.

Authentication is supported through an access token that must be created in the settings of the Github Enterprise account.


Closes #145
Closes #148