### PR TITLE
Scrape Everything From Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Gitrob is a tool to help find potentially sensitive files pushed to public repos
     Suppress all output except for errors
 -threads int
     Number of concurrent threads (default number of logical CPUs)
+-gather-all
+    Specify whether to pull all repositories from the domain
 ```
 
 ### Saving session to a file

--- a/core/git.go
+++ b/core/git.go
@@ -3,7 +3,6 @@ package core
 import (
   "fmt"
   "io/ioutil"
-
   "gopkg.in/src-d/go-git.v4"
   "gopkg.in/src-d/go-git.v4/plumbing"
   "gopkg.in/src-d/go-git.v4/plumbing/object"
@@ -14,9 +13,14 @@ const (
   EmptyTreeCommitId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 )
 
-func CloneRepository(url *string, branch *string, depth int) (*git.Repository, string, error) {
-  urlVal := *url
-  branchVal := *branch
+func CloneRepository(repo *GithubRepository, depth int) (*git.Repository, string, error) {
+  var urlVal string
+  if repo.CloneURL != nil {
+    urlVal = *repo.CloneURL
+  } else {
+    urlVal = *repo.URL
+  }
+  branchVal := *repo.DefaultBranch
   dir, err := ioutil.TempDir("", "gitrob")
   if err != nil {
     return nil, "", err

--- a/core/github.go
+++ b/core/github.go
@@ -2,7 +2,6 @@ package core
 
 import (
   "context"
-
   "github.com/google/go-github/github"
 )
 
@@ -110,4 +109,91 @@ func GetOrganizationMembers(login *string, client *github.Client) ([]*GithubOwne
     opt.Page = resp.NextPage
   }
   return allMembers, nil
+}
+
+func DetermineRepositoryCount(client *github.Client) (int64, error){
+  ctx := context.Background()
+  opt := &github.RepositoryListAllOptions{
+    Since: 0,
+  }
+
+  sinceValue := 0
+  lastValue := 0
+
+  for {
+    repos, _, err := client.Repositories.ListAll(ctx, opt)
+    if err != nil {
+      return -1, err
+    }
+    for _, repo := range repos {
+      if !*repo.Fork {
+        sinceValue = int(*repo.ID)
+      }
+    }
+    if len(repos) == 0 {
+      if sinceValue == lastValue { 
+        return int64(sinceValue), nil
+      }
+      sinceValue = (lastValue + sinceValue) / 2 
+    } else {
+      lastValue = sinceValue
+      sinceValue *= 2
+    }
+
+
+    opt = &github.RepositoryListAllOptions{
+      Since: int64(sinceValue),
+    }
+  }
+  return 0, nil
+}
+
+func GetAllRepositories(client *github.Client, start int64, end int64) ([]*GithubRepository, error) {
+  var allRepos []*GithubRepository
+  ctx := context.Background()
+  opt := &github.RepositoryListAllOptions{
+    Since: start,
+  }
+
+  hard_coded_branch := "master"
+
+  scraped := false
+  sinceValue := start
+
+  for scraped != true {
+    repos, _, err := client.Repositories.ListAll(ctx, opt)
+    if err != nil {
+      return allRepos, err
+    }
+    for _, repo := range repos {
+      if !*repo.Fork {
+        r := GithubRepository{
+          Owner:         repo.Owner.Login,
+          ID:            repo.ID,
+          Name:          repo.Name,
+          FullName:      repo.FullName,
+          CloneURL:      repo.CloneURL,
+          URL:           repo.HTMLURL,
+          DefaultBranch: &hard_coded_branch,
+          Description:   repo.Description,
+          Homepage:      repo.Homepage,
+        }
+        allRepos = append(allRepos, &r)
+
+        sinceValue = int64(*r.ID)
+
+        if sinceValue >= end {
+          return allRepos, nil
+        }
+      }
+    }
+    if len(repos) == 0 {
+      scraped = true
+    }
+    opt = &github.RepositoryListAllOptions{
+      Since: int64(sinceValue),
+    }
+  }
+
+  return allRepos, nil
 }

--- a/core/options.go
+++ b/core/options.go
@@ -8,6 +8,7 @@ type Options struct {
   CommitDepth       *int
   GithubAccessToken *string `json:"-"`
   NoExpandOrgs      *bool
+  GatherAll         *bool
   Threads           *int
   Save              *string `json:"-"`
   Load              *string `json:"-"`
@@ -23,6 +24,7 @@ func ParseOptions() (Options, error) {
     CommitDepth:       flag.Int("commit-depth", 500, "Number of repository commits to process"),
     GithubAccessToken: flag.String("github-access-token", "", "GitHub access token to use for API requests"),
     NoExpandOrgs:      flag.Bool("no-expand-orgs", false, "Don't add members to targets when processing organizations"),
+    GatherAll:         flag.Bool("gather-all", false, "Gather all repositories on the domain"),
     Threads:           flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)"),
     Save:              flag.String("save", "", "Save session to file"),
     Load:              flag.String("load", "", "Load session file"),


### PR DESCRIPTION
## Pull Request for #163 

Made use of the [ListAll method](https://github.com/google/go-github/blob/master/github/repos.go#L242) to implement the ability to scrape all repositories. A binary search was implemented to determine the upper limit of repositories. This was then split evenly between threads so that large numbers of repositories could be pulled concurrently.

Currently only the master branch is pulled from repositories. This helps prevent path explosion, but could be improved in the future.


**Closing issues**
closes #163 
